### PR TITLE
State object to consist of map of functions

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -45,6 +45,7 @@ export default {
       acc[f.namespace] = f.context;
       return acc;
     }, {});
+
     return initSqlJs({
       locateFile: args?.wasmFile ? () => args?.wasmFile : undefined,
     })
@@ -83,11 +84,15 @@ export default {
 
             // state is being accessed
             if (name === "state") {
-              let sql = receiver._db.prepare(`select * from state;`);
-              const partialState = sql.getAsObject([]);
-              delete partialState.id;
+              let sql = db.prepare(`select * from state;`);
 
-              return args.buildState(partialState, receiver);
+              const columns = sql.getColumnNames().filter(v => v !== "id");
+              let partial = {}
+              for (let c of columns) {
+                partial[c] = (() => sql.getAsObject([])?.[c])
+              }
+
+              return args.buildState(partial, receiver);
             }
 
             // one of the features

--- a/test/state.test.js
+++ b/test/state.test.js
@@ -6,24 +6,27 @@ describe("state", function () {
     const core = await Core.init();
     assert.notStrictEqual(core.state, {});
   });
-  it("core.state returns declared state columns", async function () {
+  it("core.state returns declared state columns as functions", async function () {
     const core = await Core.init({
-      stateColumns: ["my_column integer"],
+      stateColumns: ["my_column integer default 123"],
     });
-    assert.notStrictEqual(core.state, { my_column: null });
+    assert.ok(typeof core.state.my_column === "function")
+    assert.strictEqual(core.state.my_column(), 123);
   });
 
   it("core.state calls buildState", async function () {
     let calls = 0;
     const core = await Core.init({
+      stateColumns: ["my_column integer default 2"],
       buildState: (partial, core) => {
         calls++;
-        assert.notStrictEqual(partial, {});
+        assert.ok(typeof partial.my_column === "function")
+        assert.strictEqual(partial.my_column(), 2);
         assert.ok(core); //gets a truthy value
         return { my_state: true };
       },
     });
-    assert.notStrictEqual(core.state, { my_column: null });
+    assert.strictEqual(core.state.my_state, true);
     assert.strictEqual(calls, 1);
   });
 });


### PR DESCRIPTION
Each key should map to a function. This allows clients to lazily retrieve data (through individual sql statements).

Currently, the state object is rebuilt on each access to `mem.state`, which is undesirable for performance (as all context functions used in `buildState` will be executed).